### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,291 @@
+# Changelog
+
+All notable changes to `likeminds-feed-reactjs`, generated from its GitHub Releases.
+
+Full release history: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases
+
+---
+
+## [1.12.0] - 2025-06-05
+
+### What's Changed
+* [LM-12280] Send height and width in attachment meta by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/141
+* [LM-12400] Retry Mechanism by @sumitBora12 in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/139
+* [LM-13816] PSO bugs by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/143
+* Release v1.12.0 by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/142
+
+### New Contributors
+* @sumitBora12 made their first contribution in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/139
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.11.1...v1.12.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.12.0)
+
+## [1.11.1] - 2025-04-24
+
+### What's Changed
+* Release v1.11.0 - Hotfix for Jenkinsfile by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/137
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.11.0...v1.11.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.11.1)
+
+## [1.11.0] - 2025-04-24 Release 1.11.0
+
+### What's Changed
+* Release v1.11.0 by @ishaan1607 in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/136
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.10.0...v1.11.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.11.0)
+
+## [1.10.0] - 2025-04-14
+
+### What's Changed
+* Hotfix v1.8.1 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/129
+* [WIP] [LM-13573] Choice reported issue by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/130
+* [LM-13606] Automate build environment by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/131
+* Release v1.9.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/132
+* Release v1.9.1 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/133
+* [LM-13547] Moderation and Feed Improvements by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/128
+* Release v1.10.0 by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/134
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.8.0...v1.10.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.10.0)
+
+## [1.8.0] - 2025-03-08
+
+### What's Changed
+* LM-13508 Api Revamp by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/125
+* [LM-13252] Redirection bug fixes by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/121
+* LM-12858 Moderation in Feed by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/119
+* [LM-13534] Pso Bugs by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/127
+* Release v1.8.0 by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/126
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.7.2...v1.8.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.8.0)
+
+## [1.7.2] - 2025-02-28
+
+### What's Changed
+* [LM-13427] LmMeta key Updated by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/123
+* [LM-13478] Community Configuration Key Fixed by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/122
+* Release/v1.7.2 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/124
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.7.1...v1.7.2
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.7.2)
+
+## [1.7.1] - 2024-12-16
+
+### What's Changed
+* Release v1.7.1 by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/118
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.7.0...v1.7.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.7.1)
+
+## [1.7.0] - 2024-12-11
+
+### What's Changed
+* [LM-11697] Poll in feed by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/112
+* [LM-12956] Feed bug fixes by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/111
+* Revert "[LM-11697] Poll in feed" by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/114
+* [LM-11697] Poll in feed by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/115
+* Release v1.7.0 pso by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/116
+* Release v1.7.0 by @yashsajwanlm in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/117
+
+### New Contributors
+* @yashsajwanlm made their first contribution in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/112
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.6.2...v1.7.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.7.0)
+
+## [1.6.2] - 2024-11-15
+
+### What's Changed
+* [LM-13076] Dependencies Error by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/113
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.6.0...v1.6.2
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.6.2)
+
+## [1.6.0] - 2024-11-11
+
+### What's Changed
+* Release V1.6.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/108
+* Release v1.6.1 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/109
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.5.0...v1.6.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.6.0)
+
+## [1.5.0] - 2024-10-17
+
+### What's Changed
+* Release v1.5.0 by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/100
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.4.1...v1.5.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.5.0)
+
+## [1.4.1] - 2024-09-30
+
+### What's Changed
+* Release v1.4.1 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/94
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.4.0...v1.4.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.4.1)
+
+## [1.4.0] - 2024-09-17
+
+### What's Changed
+* [LM-12770] Support thumbnails reels by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/87
+* [LM-12786] Peer testing bugs fixed and version updated by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/88
+* Release/v1.4.0 by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/89
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.3.1...v1.4.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.4.0)
+
+## [1.3.1] - 2024-09-13
+
+### What's Changed
+* Release v1.3.1 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/86
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.3.0...v1.3.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.3.1)
+
+## [1.3.0] - 2024-09-11
+
+### What's Changed
+* Release V1.3.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/85
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.2.3...v1.3.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.3.0)
+
+## [1.2.3] - 2024-08-30
+
+### What's Changed
+* Release v1.2.3 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/81
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.2.2...v1.2.3
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.2.3)
+
+## [1.2.2] - 2024-08-20
+
+### What's Changed
+* Release/v1.2.2 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/80
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.2.1...v1.2.2
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.2.2)
+
+## [1.2.1] - 2024-08-14
+
+### What's Changed
+* Release v1.2.1 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/79
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.2.0...v1.2.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.2.1)
+
+## [1.2.0] - 2024-08-14
+
+### What's Changed
+* Release v.1.1.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/74
+* Release v1.2.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/78
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v1.0.0...v1.2.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.2.0)
+
+## [1.0.0] - 2024-04-25
+
+### What's Changed
+* Release v1.0.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/69
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v0.6.0...v1.0.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v1.0.0)
+
+## [0.6.0] - 2024-03-28
+
+### What's Changed
+* [LM-10926] Added API Security by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/34
+* Release v0.6.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/35
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/compare/v0.5.0...v0.6.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v0.6.0)
+
+## [0.5.0] - 2024-03-21
+
+### What's Changed
+* [LM-10773] - View Post by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/1
+* Feature/lm 10774 topic feed by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/2
+* Added Feed post context && added infinite scroll by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/3
+* Feature/lm 10773 view post by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/4
+* Feature/lm 10773 view post by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/5
+* Feature/lm 10774 topic feed by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/6
+* Feature/lm 10773 view post by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/7
+* Feature/lm 10774 topic feed by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/8
+* added Topic Feed Modules by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/9
+* Feature/lm 10775 comment and replies by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/10
+* [LM-10773] view post by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/11
+* Feature/lm 10775 comment and replies by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/12
+* updated styles by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/13
+* Post Detail page UI changes by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/14
+* Feature/lm 10775 comment and replies by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/15
+* Added topics by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/16
+* Feature/lm 10773 view post by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/17
+* post detail page ui changes by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/18
+* Feature/lm 10775 comment and replies by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/19
+* Feature/lm 10773 view post by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/20
+* files renamed by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/21
+* UI responsive related changes by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/22
+* [LM-10775] :  Comment and Replies by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/23
+* [LM-10486]: Added callbacks interface by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/24
+* [LM-10780] - Topic feed ui fixed by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/25
+* [LM-10775] Fixed Replies time issue by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/26
+* [LM-10775] Added Changes As per firebase by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/27
+* [LM-10780] - sitmap.xml updated by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/28
+* [LM-10931] Fixed: reply comment css issue by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/29
+* [LM-10946] Added: PR Template  by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/31
+* [LM-10775] Added keys by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/30
+* [LM-10486] Feed v0.5.0 by @omenUchiha in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/32
+* Release v0.5.0 by @sanjaylikeminds in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/33
+
+### New Contributors
+* @sanjaylikeminds made their first contribution in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/1
+* @omenUchiha made their first contribution in https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/pull/2
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/commits/v0.5.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-feed-reactjs/releases/tag/v0.5.0)


### PR DESCRIPTION
Generated from this repo's GitHub Releases: every published version with its date and release notes, newest first.

Anyone upgrading a published package currently has to read git history or click through the Releases page to find out what changed. This puts it in the repo where people look for it.

Nothing is invented - each entry is the release body as written, with headings demoted one level so they nest under the version. Each entry links back to its release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)