### PR TITLE
Note that the Jenkinsfile is not operational

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ Security issues go to **natesh@likeminds.community**, not the issue tracker.
 ## License
 
 Apache 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+
+---
+
+## A note on the Jenkinsfile
+
+The `Jenkinsfile` in this repo is **retained for historical reference and is not operational**. The
+Jenkins server it ran on was decommissioned in August 2026.
+
+It performed a build-and-archive step that nothing downstream consumed. Publishing has always run
+through the GitHub Actions workflows in `.github/workflows`, which are unaffected.


### PR DESCRIPTION
The Jenkins server this `Jenkinsfile` ran on was decommissioned in August 2026, so it no longer executes.

It performed a build-and-archive step - install, build, pack, archive the tarball on the Jenkins box - that nothing downstream consumed. Publishing has always run through the GitHub Actions workflows in `.github/workflows`, which were never affected.

Keeping the file, adding a README note so nobody reads it as the current build process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)